### PR TITLE
FAODEL: Update FAODEL package

### DIFF
--- a/var/spack/repos/builtin/packages/faodel/array.patch
+++ b/var/spack/repos/builtin/packages/faodel/array.patch
@@ -1,0 +1,11 @@
+diff --git a/src/common/Configuration.cpp b/src/common/Configuration.cpp
+index f844488..70186cc 100644
+--- a/src/common/Configuration.cpp
++++ b/src/common/Configuration.cpp
+@@ -1,4 +1,5 @@
+
++#include <array>
+ #include <vector>
+ #include <map>
+ #include <algorithm>
+


### PR DESCRIPTION
@fbudin69500 @chuckatkins  I have incorporated some changes from the package file we have been testing internally.
- We have identified minimum versions of the Boost, CMake and libfabric packages that have the features required for FAODEL.  I have added those versions to the `depends_on()` calls.
- There is a bug in Boost.Log v1.59.0 that causes failures in FAODEL.  I have added a conflict for that version.
- FAODEL doesn't make use of the Boost MPI wrappers, so I have remove `+mpi` / `~mpi` and reduced the Boost `depends_on()` to just one.
- There are two FAODEL v1.1803.1 specific fixes (a patch and a depends)
- The MPI and SBL patches only apply to v1.1803.1, so I added a `when=@1.1811.1`
- FAODEL requires a C++11 compiler, so I added a minimum version check for GCC

@craigulmer These changes tested OK on the usual platforms.
